### PR TITLE
Fix wildcard route for Express 5

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -34,7 +34,7 @@ const publicPath = path.join(process.cwd(), 'dist/public');
 app.use(express.static(publicPath));
 
 // Servir index.html para rotas SPA
-app.get('*', (req, res, next) => {
+app.get('/*splat', (req, res, next) => {
   if (req.path.startsWith('/api')) {
     next();
   } else {


### PR DESCRIPTION
## Summary
- adjust wildcard catch-all route to use Express 5 syntax

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx tsx server/index.ts`

------
https://chatgpt.com/codex/tasks/task_e_6859ab68bea88322ae172fc77eebcc9f