### PR TITLE
Expand chat area width

### DIFF
--- a/client/src/components/ChatIA.tsx
+++ b/client/src/components/ChatIA.tsx
@@ -331,7 +331,7 @@ export default function ChatIA({ projectId, fileId, selectedCode, language }: Ch
       )}
 
       {/* Input - Fixo na parte inferior, sem overlap */}
-      <div className="flex-shrink-0 p-2 border-t border-gray-700 bg-gray-800 sticky bottom-0">
+      <div className="flex-shrink-0 p-2 border-t border-gray-700 bg-gray-800">
         <div className="flex space-x-2">
           <div className="flex-1">
             <textarea

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -94,7 +94,7 @@ body {
   grid-template-areas: 
     "sidebar header header"
     "sidebar editor chat";
-  grid-template-columns: 280px 1fr 350px;
+  grid-template-columns: 280px 1fr 450px;
   grid-template-rows: 60px 1fr;
   gap: 1px;
   background-color: hsl(var(--border));
@@ -118,6 +118,10 @@ body {
 .ide-chat {
   grid-area: chat;
   background: hsl(var(--card));
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
 }
 
 @media (max-width: 1024px) {


### PR DESCRIPTION
## Summary
- widen the chat panel column width
- refine chat pane layout to keep the input visible and messages scrollable

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6859a9303288832296e00e85f2e4391e